### PR TITLE
infra: normalize EXAMPLE_DIR on Windows for Meson example build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,10 @@ project('thorvg.example',
   default_options: ['buildtype=debugoptimized', 'cpp_std=c++14', 'optimization=3'],
   license : 'MIT')
 
-add_project_arguments('-DEXAMPLE_DIR="@0@/res"'.format(meson.current_source_dir()), language : 'cpp')
+example_dir = meson.current_source_dir()
+if host_machine.system() == 'windows'
+  example_dir = example_dir.replace('\\', '/')
+endif
+add_project_arguments('-DEXAMPLE_DIR="@0@/res"'.format(example_dir), language : 'cpp')
 
 subdir('src')


### PR DESCRIPTION
## Summary
- Normalize the example resource path on Windows before injecting it into EXAMPLE_DIR.

## Reason
- Avoid backslash escape sequences in the C++ string literal.
