### PR TITLE
fix: Use premultiplied WG color space in examples

### DIFF
--- a/src/Example.h
+++ b/src/Example.h
@@ -517,7 +517,7 @@ struct WgWindow : Window
     void resize() override
     {
         //Set the canvas target and draw on it.
-        verify(static_cast<tvg::WgCanvas*>(canvas)->target(device, instance, surface, width, height, tvg::ColorSpace::ABGR8888S));
+        verify(static_cast<tvg::WgCanvas*>(canvas)->target(device, instance, surface, width, height, tvg::ColorSpace::ABGR8888));
     }
 
     void refresh() override 

--- a/src/MultiCanvas.cpp
+++ b/src/MultiCanvas.cpp
@@ -355,7 +355,7 @@ bool runWg()
         auto canvas = unique_ptr<tvg::WgCanvas>(tvg::WgCanvas::gen());
 
         //Set the canvas target and draw on it.
-        tvgexam::verify(canvas->target(device, instance, renderTarget, SIZE, SIZE, tvg::ColorSpace::ABGR8888S, 1));
+        tvgexam::verify(canvas->target(device, instance, renderTarget, SIZE, SIZE, tvg::ColorSpace::ABGR8888, 1));
 
         content(canvas.get());
         if (tvgexam::verify(canvas->draw())) {


### PR DESCRIPTION
Update the WebGPU example targets to use premultiplied ABGR8888 color space, matching new ThorVG WG behavior.

This PR can be merged only after https://github.com/thorvg/thorvg/pull/4471 has been merged.