### PR TITLE
Revert "fix: Use premultiplied WG color space in examples"

### DIFF
--- a/src/Example.h
+++ b/src/Example.h
@@ -517,7 +517,7 @@ struct WgWindow : Window
     void resize() override
     {
         //Set the canvas target and draw on it.
-        verify(static_cast<tvg::WgCanvas*>(canvas)->target(device, instance, surface, width, height, tvg::ColorSpace::ABGR8888));
+        verify(static_cast<tvg::WgCanvas*>(canvas)->target(device, instance, surface, width, height, tvg::ColorSpace::ABGR8888S));
     }
 
     void refresh() override 

--- a/src/MultiCanvas.cpp
+++ b/src/MultiCanvas.cpp
@@ -355,7 +355,7 @@ bool runWg()
         auto canvas = unique_ptr<tvg::WgCanvas>(tvg::WgCanvas::gen());
 
         //Set the canvas target and draw on it.
-        tvgexam::verify(canvas->target(device, instance, renderTarget, SIZE, SIZE, tvg::ColorSpace::ABGR8888, 1));
+        tvgexam::verify(canvas->target(device, instance, renderTarget, SIZE, SIZE, tvg::ColorSpace::ABGR8888S, 1));
 
         content(canvas.get());
         if (tvgexam::verify(canvas->draw())) {


### PR DESCRIPTION
Reverts thorvg/thorvg.example#42