### PR TITLE
[webgpu] Use WebGPU context API for ThorVG targets

### DIFF
--- a/src/Example.h
+++ b/src/Example.h
@@ -517,7 +517,8 @@ struct WgWindow : Window
     void resize() override
     {
         //Set the canvas target and draw on it.
-        verify(static_cast<tvg::WgCanvas*>(canvas)->target(device, instance, surface, width, height, tvg::ColorSpace::ABGR8888S));
+        tvg::WgCanvas::Context context = {instance, adapter, device};
+        verify(static_cast<tvg::WgCanvas*>(canvas)->target(context, surface, width, height, tvg::ColorSpace::ABGR8888));
     }
 
     void refresh() override 

--- a/src/MultiCanvas.cpp
+++ b/src/MultiCanvas.cpp
@@ -355,7 +355,8 @@ bool runWg()
         auto canvas = unique_ptr<tvg::WgCanvas>(tvg::WgCanvas::gen());
 
         //Set the canvas target and draw on it.
-        tvgexam::verify(canvas->target(device, instance, renderTarget, SIZE, SIZE, tvg::ColorSpace::ABGR8888S, 1));
+        tvg::WgCanvas::Context context = {instance, adapter, device};
+        tvgexam::verify(canvas->target(context, renderTarget, SIZE, SIZE, tvg::ColorSpace::ABGR8888, 1));
 
         content(canvas.get());
         if (tvgexam::verify(canvas->draw())) {


### PR DESCRIPTION
Motivation:
ThorVG now exposes WgCanvas::Context so callers can provide the WebGPU adapter together with the instance and device. The previous target overload left the adapter unset, which prevents the renderer from receiving the full WebGPU context it now tracks.

Description:
Pass {instance, adapter, device} through the new WgCanvas::target(context, ...) overload for both the main WebGPU window and the MultiCanvas offscreen render target. 