### PR TITLE
Examples: fix flickering at animation loop boundaries

### DIFF
--- a/src/Example.h
+++ b/src/Example.h
@@ -543,7 +543,7 @@ float progress(uint32_t elapsed, float durationInSec, bool rewind = false)
     auto duration = uint32_t(durationInSec * 1000.0f); //sec -> millisec.
     if (elapsed == 0 || duration == 0) return 0.0f;
     auto forward = ((elapsed / duration) % 2 == 0) ? true : false;
-    if (elapsed % duration == 0) return forward ? 0.0f : 1.0f;
+    if (elapsed % duration == 0) return rewind && !forward ? 1.0f : 0.0f;
     auto progress = (float(elapsed % duration) / (float)duration);
     if (rewind) return forward ? progress : (1 - progress);
     return progress;


### PR DESCRIPTION
Non-rewinding animations returned a progress of 1.0 at odd loop boundaries, causing Animation::frame() to receive totalFrame(). The Lottie loader clamped it to the last valid frame before jumping to frame 0, producing a visible opacity pulse.

Return 0.0 at regular loop boundaries while preserving 1.0 at the turning point of rewind playback.

issue: https://github.com/thorvg/thorvg/issues/4566


### Screenshot



https://github.com/user-attachments/assets/e7161768-4204-45dc-95ce-90f567d3daa7


### REPRODUCE2

animation example 

```json
{
    "v": "5.7.4",
    "fr": 10,
    "ip": 0,
    "op": 10,
    "w": 800,
    "h": 800,
    "layers": [
        {
            "ty": 1,
            "sw": 100,
            "sh": 100,
            "sc": "#3278ff",
            "ip": 0,
            "op": 10,
            "ks": {
                "o": {"a": 0, "k": 100},
                "p": {"a": 0, "k": [400, 400]},
                "a": {"a": 0, "k": [50, 50]},
                "s": {"a": 0, "k": [100, 100]},
                "r": {"a": 0, "k": 0}
            }
        },
        {
            "ty": 1,
            "sw": 500,
            "sh": 500,
            "sc": "#ff3030",
            "ip": 9,
            "op": 9.01,
            "ks": {
                "o": {"a": 0, "k": 100},
                "p": {"a": 0, "k": [400, 400]},
                "a": {"a": 0, "k": [250, 250]},
                "s": {"a": 0, "k": [100, 100]},
                "r": {"a": 0, "k": 0}
            }
        }
    ]
}

```