### PR TITLE
example: fix initial FPS calculation

### DIFF
--- a/src/Example.h
+++ b/src/Example.h
@@ -211,7 +211,7 @@ struct Window
 
         using clock = std::chrono::steady_clock;
 
-        static double ema_dt = 1 / 60;             // Initial value assuming 60fps (seconds)
+        static double ema_dt = 1.0 / 60.0;             // Initial value assuming 60fps (seconds)
         static const double half_life = 0.25;      // Half-life of 0.25 seconds (lightly tuned)
         static auto prev = clock::now();
 


### PR DESCRIPTION
The initial value of `ema_dt` is zero, causing the FPS to be significantly overestimated at startup. 
This change initializes it to `60 FPS`, as described in the comment.
 

 I verified it by adding logging to the `Window::fps()` function.

 ```cpp
     void fps(uint32_t tickCnt, uint32_t ctime)
    {
        if (tickCnt == 1) printf("[ Boot]: %u(ms)\n", ctime - stime);

        using clock = std::chrono::steady_clock;

        static double ema_dt = 1 / 60;             // Initial value assuming 60fps (seconds)
        static const double half_life = 0.25;      // Half-life of 0.25 seconds (lightly tuned)
        static auto prev = clock::now();

        auto now = clock::now();
        auto dt = std::chrono::duration<double>(now - prev).count();   // Time elapsed in seconds
        prev = now;

        // Clamp abnormally large dt (e.g., during tab switching or pausing in debugger)
        if (dt > 0.25) dt = 0.25;  // Cap at 250ms

        // Continuous time-based alpha: maintains responsiveness regardless of framerate
        auto alpha = 1 - std::exp(-std::log(2) * dt / half_life);
        ema_dt += alpha * (dt - ema_dt);
        printf("[%5d]: %0.2f fps, %0.2f ms\n", tickCnt, 1 / ema_dt, ema_dt * 1000.0);

        // Skip the unstable first 60 frames, also no need to print every frame.
        if (tickCnt > 59) {
            auto result = 1 / ema_dt;
            mfps += result;
            if (tickCnt % 10 == 0) printf("[%5d]: %0.2f / %0.2f fps\n", tickCnt, result, mfps / (tickCnt - 59));
            exit(0);
        }
    }
 ```

### main

```cpp
[    1]: 204463594793601.00 fps, 0.00 ms
[    2]: 474075103.35 fps, 0.00 ms
[    3]: 77880.54 fps, 0.01 ms
[    4]: 14526.06 fps, 0.07 ms
[    5]: 6696.94 fps, 0.15 ms
[    6]: 6447.46 fps, 0.16 ms
[    7]: 3227.21 fps, 0.31 ms
[    8]: 1768.43 fps, 0.57 ms
[    9]: 1211.53 fps, 0.83 ms
[   10]: 929.86 fps, 1.08 ms
[   11]: 930.19 fps, 1.08 ms
[   12]: 665.22 fps, 1.50 ms
[   13]: 572.90 fps, 1.75 ms
[   14]: 451.95 fps, 2.21 ms
[   15]: 380.11 fps, 2.63 ms
[   16]: 377.01 fps, 2.65 ms
[   17]: 342.76 fps, 2.92 ms
[   18]: 342.01 fps, 2.92 ms
[   19]: 267.25 fps, 3.74 ms
[   20]: 267.47 fps, 3.74 ms
[   21]: 263.88 fps, 3.79 ms
[   22]: 264.50 fps, 3.78 ms
[   23]: 248.37 fps, 4.03 ms
[   24]: 238.45 fps, 4.19 ms
[   25]: 218.51 fps, 4.58 ms
[   26]: 218.94 fps, 4.57 ms
[   27]: 200.09 fps, 5.00 ms
[   28]: 200.42 fps, 4.99 ms
[   29]: 184.81 fps, 5.41 ms
[   30]: 185.44 fps, 5.39 ms
[   31]: 161.98 fps, 6.17 ms
[   32]: 162.61 fps, 6.15 ms
[   33]: 158.23 fps, 6.32 ms
[   34]: 158.19 fps, 6.32 ms
[   35]: 141.63 fps, 7.06 ms
[   36]: 142.18 fps, 7.03 ms
[   37]: 141.68 fps, 7.06 ms
[   38]: 140.61 fps, 7.11 ms
[   39]: 135.36 fps, 7.39 ms
[   40]: 129.48 fps, 7.72 ms
[   41]: 127.90 fps, 7.82 ms
[   42]: 128.17 fps, 7.80 ms
[   43]: 128.80 fps, 7.76 ms
[   44]: 127.24 fps, 7.86 ms
[   45]: 126.26 fps, 7.92 ms
[   46]: 126.72 fps, 7.89 ms
[   47]: 120.49 fps, 8.30 ms
[   48]: 121.11 fps, 8.26 ms
[   49]: 119.79 fps, 8.35 ms
[   50]: 118.38 fps, 8.45 ms
[   51]: 119.06 fps, 8.40 ms
[   52]: 114.01 fps, 8.77 ms
[   53]: 114.71 fps, 8.72 ms
[   54]: 110.62 fps, 9.04 ms
[   55]: 109.31 fps, 9.15 ms
[   56]: 109.02 fps, 9.17 ms
[   57]: 109.66 fps, 9.12 ms
[   58]: 110.09 fps, 9.08 ms
[   59]: 110.03 fps, 9.09 ms
[   60]: 109.48 fps, 9.13 ms
[   60]: 109.48 / 109.48 fps
```

### fetch 

```cpp
[    1]: 60.00 fps, 16.67 ms
[    2]: 60.67 fps, 16.48 ms
[    3]: 61.09 fps, 16.37 ms
[    4]: 61.25 fps, 16.33 ms
[    5]: 61.94 fps, 16.14 ms
[    6]: 62.59 fps, 15.98 ms
[    7]: 63.06 fps, 15.86 ms
[    8]: 63.66 fps, 15.71 ms
[    9]: 64.24 fps, 15.57 ms
[   10]: 64.61 fps, 15.48 ms
[   11]: 65.11 fps, 15.36 ms
[   12]: 65.50 fps, 15.27 ms
[   13]: 66.04 fps, 15.14 ms
[   14]: 66.65 fps, 15.00 ms
[   15]: 67.25 fps, 14.87 ms
[   16]: 67.93 fps, 14.72 ms
[   17]: 68.54 fps, 14.59 ms
[   18]: 67.27 fps, 14.87 ms
[   19]: 67.65 fps, 14.78 ms
[   20]: 68.12 fps, 14.68 ms
[   21]: 68.72 fps, 14.55 ms
[   22]: 68.24 fps, 14.65 ms
[   23]: 68.80 fps, 14.54 ms
[   24]: 69.05 fps, 14.48 ms
[   25]: 69.57 fps, 14.37 ms
[   26]: 69.74 fps, 14.34 ms
[   27]: 70.30 fps, 14.22 ms
[   28]: 70.20 fps, 14.24 ms
[   29]: 70.77 fps, 14.13 ms
[   30]: 71.21 fps, 14.04 ms
[   31]: 70.42 fps, 14.20 ms
[   32]: 70.76 fps, 14.13 ms
[   33]: 70.92 fps, 14.10 ms
[   34]: 70.76 fps, 14.13 ms
[   35]: 71.06 fps, 14.07 ms
[   36]: 71.64 fps, 13.96 ms
[   37]: 72.19 fps, 13.85 ms
[   38]: 72.35 fps, 13.82 ms
[   39]: 72.79 fps, 13.74 ms
[   40]: 73.49 fps, 13.61 ms
[   41]: 72.95 fps, 13.71 ms
[   42]: 73.61 fps, 13.58 ms
[   43]: 73.06 fps, 13.69 ms
[   44]: 73.71 fps, 13.57 ms
[   45]: 74.38 fps, 13.44 ms
[   46]: 73.63 fps, 13.58 ms
[   47]: 74.30 fps, 13.46 ms
[   48]: 73.86 fps, 13.54 ms
[   49]: 74.11 fps, 13.49 ms
[   50]: 74.65 fps, 13.40 ms
[   51]: 75.18 fps, 13.30 ms
[   52]: 75.58 fps, 13.23 ms
[   53]: 76.27 fps, 13.11 ms
[   54]: 76.74 fps, 13.03 ms
[   55]: 77.25 fps, 12.94 ms
[   56]: 77.73 fps, 12.86 ms
[   57]: 78.22 fps, 12.78 ms
[   58]: 78.69 fps, 12.71 ms
[   59]: 79.15 fps, 12.63 ms
[   60]: 79.60 fps, 12.56 ms
[   60]: 79.60 / 79.60 fps
```

