### PR TITLE
wgpu: fix the crash on Wayland sessions

### DIFF
--- a/src/Example.h
+++ b/src/Example.h
@@ -446,34 +446,57 @@ struct WgWindow : Window
         WGPUInstanceDescriptor desc{};
         instance = wgpuCreateInstance(&desc);
 
-        #if defined(SDL_VIDEO_DRIVER_COCOA)
-            [windowWMInfo.info.cocoa.window.contentView setWantsLayer:YES];
-            auto layer = [CAMetalLayer layer];
-            [windowWMInfo.info.cocoa.window.contentView setLayer:layer];
+        // windowWMInfo.subsystem tells which member of the windowWMInfo.info union is valid.
+        union {
+            WGPUSurfaceSourceMetalLayer cocoa;
+            WGPUSurfaceSourceXlibWindow x11;
+            WGPUSurfaceSourceWaylandSurface wl;
+            WGPUSurfaceSourceWindowsHWND win;
+        } surfaceNativeDesc{};
 
-            WGPUSurfaceSourceMetalLayer surfaceNativeDesc = {
-                .chain = {nullptr, WGPUSType_SurfaceSourceMetalLayer},
-                .layer = layer
-            };
-        #elif defined(SDL_VIDEO_DRIVER_X11)
-            WGPUSurfaceSourceXlibWindow surfaceNativeDesc = {
-                .chain = {nullptr, WGPUSType_SurfaceSourceXlibWindow},
-                .display = windowWMInfo.info.x11.display,
-                .window = windowWMInfo.info.x11.window
-            };
-        #elif defined(SDL_VIDEO_DRIVER_WAYLAND)
-        WGPUSurfaceSourceWaylandSurface surfaceNativeDesc = {
-                .chain = {nullptr, WGPUSType_SurfaceSourceWaylandSurface},
-                .display = windowWMInfo.info.wl.display,
-                .surface = windowWMInfo.info.wl.surface
-            };
-        #elif defined(SDL_VIDEO_DRIVER_WINDOWS)
-            WGPUSurfaceSourceWindowsHWND surfaceNativeDesc = {
-                .chain = {nullptr, WGPUSType_SurfaceSourceWindowsHWND},
-                .hinstance = GetModuleHandle(nullptr),
-                .hwnd = windowWMInfo.info.win.window
-            };
+        switch (windowWMInfo.subsystem) {
+        #if defined(SDL_VIDEO_DRIVER_COCOA)
+            case SDL_SYSWM_COCOA: {
+                [windowWMInfo.info.cocoa.window.contentView setWantsLayer:YES];
+                auto layer = [CAMetalLayer layer];
+                [windowWMInfo.info.cocoa.window.contentView setLayer:layer];
+
+                surfaceNativeDesc.cocoa = {
+                    .chain = {nullptr, WGPUSType_SurfaceSourceMetalLayer},
+                    .layer = layer
+                };
+                break;
+            }
         #endif
+        #if defined(SDL_VIDEO_DRIVER_X11)
+            case SDL_SYSWM_X11:
+                surfaceNativeDesc.x11 = {
+                    .chain = {nullptr, WGPUSType_SurfaceSourceXlibWindow},
+                    .display = windowWMInfo.info.x11.display,
+                    .window = windowWMInfo.info.x11.window
+                };
+                break;
+        #endif
+        #if defined(SDL_VIDEO_DRIVER_WAYLAND)
+            case SDL_SYSWM_WAYLAND:
+                surfaceNativeDesc.wl = {
+                    .chain = {nullptr, WGPUSType_SurfaceSourceWaylandSurface},
+                    .display = windowWMInfo.info.wl.display,
+                    .surface = windowWMInfo.info.wl.surface
+                };
+                break;
+        #endif
+        #if defined(SDL_VIDEO_DRIVER_WINDOWS)
+            case SDL_SYSWM_WINDOWS:
+                surfaceNativeDesc.win = {
+                    .chain = {nullptr, WGPUSType_SurfaceSourceWindowsHWND},
+                    .hinstance = GetModuleHandle(nullptr),
+                    .hwnd = windowWMInfo.info.win.window
+                };
+                break;
+        #endif
+            default: break;
+        }
 
         // create surface
         WGPUSurfaceDescriptor surfaceDesc{};

--- a/src/MultiCanvas.cpp
+++ b/src/MultiCanvas.cpp
@@ -281,33 +281,57 @@ bool runWg()
     WGPUInstanceDescriptor desc{};
     auto instance = wgpuCreateInstance(&desc);
 
+    // windowWMInfo.subsystem tells which member of the windowWMInfo.info union is valid.
+    union {
+        WGPUSurfaceSourceMetalLayer cocoa;
+        WGPUSurfaceSourceXlibWindow x11;
+        WGPUSurfaceSourceWaylandSurface wl;
+        WGPUSurfaceSourceWindowsHWND win;
+    } surfaceNativeDesc{};
+
+    switch (windowWMInfo.subsystem) {
     #if defined(SDL_VIDEO_DRIVER_COCOA)
-        [windowWMInfo.info.cocoa.window.contentView setWantsLayer:YES];
-        auto layer = [CAMetalLayer layer];
-        [windowWMInfo.info.cocoa.window.contentView setLayer:layer];
-        WGPUSurfaceSourceMetalLayer surfaceNativeDesc = {
-            .chain = {nullptr, WGPUSType_SurfaceSourceMetalLayer},
-            .layer = layer
-        };
-    #elif defined(SDL_VIDEO_DRIVER_X11)
-        WGPUSurfaceSourceXlibWindow surfaceNativeDesc = {
-            .chain = {nullptr, WGPUSType_SurfaceSourceXlibWindow},
-            .display = windowWMInfo.info.x11.display,
-            .window = windowWMInfo.info.x11.window
-        };
-    #elif defined(SDL_VIDEO_DRIVER_WAYLAND)
-        WGPUSurfaceSourceWaylandSurface surfaceNativeDesc = {
-            .chain = {nullptr, WGPUSType_SurfaceSourceWaylandSurface},
-            .display = windowWMInfo.info.wl.display,
-            .surface = windowWMInfo.info.wl.surface
-        };
-    #elif defined(SDL_VIDEO_DRIVER_WINDOWS)
-        WGPUSurfaceSourceWindowsHWND surfaceNativeDesc = {
-            .chain = {nullptr, WGPUSType_SurfaceSourceWindowsHWND},
-            .hinstance = GetModuleHandle(nullptr),
-            .hwnd = windowWMInfo.info.win.window
-        };
+        case SDL_SYSWM_COCOA: {
+            [windowWMInfo.info.cocoa.window.contentView setWantsLayer:YES];
+            auto layer = [CAMetalLayer layer];
+            [windowWMInfo.info.cocoa.window.contentView setLayer:layer];
+
+            surfaceNativeDesc.cocoa = {
+                .chain = {nullptr, WGPUSType_SurfaceSourceMetalLayer},
+                .layer = layer
+            };
+            break;
+        }
     #endif
+    #if defined(SDL_VIDEO_DRIVER_X11)
+        case SDL_SYSWM_X11:
+            surfaceNativeDesc.x11 = {
+                .chain = {nullptr, WGPUSType_SurfaceSourceXlibWindow},
+                .display = windowWMInfo.info.x11.display,
+                .window = windowWMInfo.info.x11.window
+            };
+            break;
+    #endif
+    #if defined(SDL_VIDEO_DRIVER_WAYLAND)
+        case SDL_SYSWM_WAYLAND:
+            surfaceNativeDesc.wl = {
+                .chain = {nullptr, WGPUSType_SurfaceSourceWaylandSurface},
+                .display = windowWMInfo.info.wl.display,
+                .surface = windowWMInfo.info.wl.surface
+            };
+            break;
+    #endif
+    #if defined(SDL_VIDEO_DRIVER_WINDOWS)
+        case SDL_SYSWM_WINDOWS:
+            surfaceNativeDesc.win = {
+                .chain = {nullptr, WGPUSType_SurfaceSourceWindowsHWND},
+                .hinstance = GetModuleHandle(nullptr),
+                .hwnd = windowWMInfo.info.win.window
+            };
+            break;
+    #endif
+        default: break;
+    }
 
     // create surface
     WGPUSurfaceDescriptor surfaceDesc{};


### PR DESCRIPTION
Each `SDL_VIDEO_DRIVER_*` macro is defined for every driver SDL was built with, so on Linux X11 and Wayland can be enabled at the same time. The surface source was chosen by an `#elif` chain on those macros, so a session actually running on Wayland could still be compiled into the X11 branch and set up the wrong surface source. It then read `SDL_SysWMinfo.info.x11` out of a union holding Wayland members, handing a `wl_display*` to Xlib, which crashed in `XGetXCBConnection()` under `wgpuInstanceRequestAdapter()` (observed on Arch Linux with sdl2-compat as an SDL3 wrapper).

Check `SDL_SysWMinfo.subsystem` and set up the surface source from the driver actually in use.